### PR TITLE
Change apiservice ingress route prefix to /api/v1

### DIFF
--- a/charts/foglifter-traefik/Chart.yaml
+++ b/charts/foglifter-traefik/Chart.yaml
@@ -4,6 +4,6 @@ description: Helm chart for FogLifter® Traefik ingress configurations
 
 type: application
 
-version: 0.1.12
+version: 0.1.13
 
 appVersion: "2.2.2"

--- a/charts/foglifter-traefik/templates/ingressroutes/apiservice.yaml
+++ b/charts/foglifter-traefik/templates/ingressroutes/apiservice.yaml
@@ -15,7 +15,7 @@ spec:
         {{- $host = (printf "Host(`%s`) && " .Values.host) }}
       {{- end }}
     {{- end }}
-    - match: {{ $host }}PathPrefix(`/api/auth`) || PathPrefix (`/api/scheduler`)
+    - match: {{ $host }}PathPrefix(`/api/v1`)
       kind: Rule
       services:
         - name: {{ default "foglifter-apiservice-svc" (.Values.apiservice).name }}

--- a/charts/foglifter-traefik/values.yaml
+++ b/charts/foglifter-traefik/values.yaml
@@ -72,7 +72,7 @@ view:
   # View app service namespace
   namespace: foglifter-view
   # View app ingress prefix
-  prefix: /dashboard
+  prefix: /dashboard/
 
 # FogLifter PGAdmin ingress configurations
 pgadmin:


### PR DESCRIPTION
### Pull Request Details

What is the purpose of this PR?

Change apiservice ingress route prefix to /api/v1


Links to tickets or documentation:



New tests: <Y/N>



Documentation Updated: <Y/N>



Is this a breaking change: <Y/N>

