### PR TITLE
FOG-188 Point nlqAgent at the agents monorepo package

### DIFF
--- a/charts/foglifter/Chart.yaml
+++ b/charts/foglifter/Chart.yaml
@@ -5,7 +5,7 @@ description: Helm chart for FogLifter® installation
 
 type: application
 
-version: 1.3.2
+version: 1.3.3
 
 appVersion: "4.12"
 dependencies:

--- a/charts/foglifter/values.yaml
+++ b/charts/foglifter/values.yaml
@@ -574,7 +574,7 @@ nlqAgent:
   # App default is 3142; forced to 8000 to match the Service/route backend
   port: 8000
   replicas: 1
-  repository: foglifter-nlq-agent
+  repository: foglifter-agents/foglifter-nlq-agent
   tag: prod
   # Postgres role/db; the role password Secret is minted by postgres-role-secrets.yaml
   postgres:


### PR DESCRIPTION
`nlqAgent.repository` was `foglifter-nlq-agent`, last published 2026-06-10 from an archived repo. The live image is `foglifter-agents/foglifter-nlq-agent` — the nested convention `assistant` already uses.

Without this, promoting nlq-agent retags a stale image.

Chart 1.3.2 to 1.3.3. `helm lint` passes; no schema change needed (shared `serviceBlock` ref).